### PR TITLE
Read replica support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ metadata:
 type: Opaque
 stringData:
   mariadb_hostname: db.maria.com
+  mariadb_reader_hostname: db.reader.maria.com
   mariadb_password: myPassword
   mariadb_port: '3306'
   mariadb_user: root
@@ -34,6 +35,7 @@ metadata:
 type: Opaque
 stringData:
   mariadb_hostname: db.maria.com
+  mariadb_reader_hostname: db.reader.maria.com
   mariadb_password: myPassword
   mariadb_port: '3306'
   mariadb_user: root
@@ -62,3 +64,6 @@ Install the [APB CLI](https://github.com/ansibleplaybookbundle/ansible-playbook-
 
 ## Release
 An automatic Docker build is set up for this repository. If you change stuff in `apb.yml` don't forget to run `apb prepare` before committing.
+
+## Reader configuration
+If the mariadb/mysql supports a reader instance aswell as a writer, you can configure the `mariadb_reader_hostname` to point to the endpoint for a reader, otherwise just populate it with the same value as the `mariadb_hostname` if one is not available

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ _apb_service_class_id: 0
 _apb_service_instance_id: 0
 
 app_name: "mariadb-{{ _apb_service_instance_id }}"
+app_reader_name: "mariadb-reader-{{ _apb_service_instance_id }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,4 @@ _apb_service_class_id: 0
 _apb_service_instance_id: 0
 
 app_name: "mariadb-{{ _apb_service_instance_id }}"
-app_reader_name: "mariadb-reader-{{ _apb_service_instance_id }}"
+app_readreplica_name: "mariadb-readreplica-{{ _apb_service_instance_id }}"

--- a/minishift-devel.sh
+++ b/minishift-devel.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+if true || [[ -z "$KUBECONFIG" ]] || [[ $(realpath "$KUBECONFIG") = $(realpath "$HOME/.kube/config") ]]; then
+	echo -e '\nThis script runs oc commands, and you are using the global ~/.kube/config.' \
+		'If you are okay with this, hit enter to confirm.' \
+		'Or use an alternative $KUBECONFIG.\n'\
+		'e.g. export KUBECONFIG=$(mktemp --tmpdir kubeconfig.XXXXXXXX)\n'
+	read
+fi
+
+# start minishift with the appropriate components
+minishift start --cpus=4 --memory=8GB
+minishift openshift component add service-catalog
+minishift openshift component add automation-service-broker
+
+# give developer cluster-admin for apb builds/installs
+oc login -u system:admin
+oc adm policy add-cluster-role-to-user cluster-admin developer
+oc login -u developer
+# perform build
+oc new-build -n openshift --binary=true --name dbaas-mariadb-apb
+oc start-build -n openshift --follow --from-dir . dbaas-mariadb-apb
+
+# wait for ASB to be deployed
+while oc get pod -n openshift-automation-service-broker | grep deploy > /dev/null; do
+	sleep 5
+done
+
+# notify the broker to search for available APBs
+# this executes asynchronously and may take a minute to finish
+while ! apb --kubeconfig="$KUBECONFIG" broker bootstrap; do
+	sleep 5
+done
+# verify that the broker found the new APB
+while ! apb --kubeconfig="$KUBECONFIG" broker catalog | grep dbaas-mariadb; do
+	sleep 5
+done
+# notify the service catalog web UI to update its catalog
+apb --kubeconfig="$KUBECONFIG" catalog relist
+
+# install the mariadb cluster
+export TILLER_NAMESPACE=tiller
+oc new-project $TILLER_NAMESPACE
+export HELM_VERSION=v2.14.3 # get this from: helm -c --short
+oc process -f https://github.com/openshift/origin/raw/master/examples/helm/tiller-template.yaml -p TILLER_NAMESPACE="${TILLER_NAMESPACE}" -p HELM_VERSION="${HELM_VERSION}" | oc create -f -
+while ! oc get pod -n tiller | grep '1/1'; do
+	sleep 5
+done
+oc new-project mariadb-cluster
+oc adm policy add-scc-to-user anyuid -z default
+oc policy add-role-to-user cluster-admin "system:serviceaccount:${TILLER_NAMESPACE}:tiller"
+helm install --name dbcluster stable/mariadb
+
+# bind the secrets into deployment pods
+updatedBrokerConfig=$(
+	# get the current configmap
+	oc -n openshift-automation-service-broker get cm broker-config -o json --export |
+	# pull out the broker-config field, which is raw YAML
+	jq -r '.data."broker-config"' |
+	# translate this YAML to JSON
+	ruby -ryaml -rjson -e 'puts YAML.load(ARGF).to_json' |
+	# append the secrets config to this JSON
+	jq '. += {secrets: [{title: "DBaaS database credentials", secret: "dbaas-db-credentials", apb_name: "localregistry-dbaas-mariadb-apb"}]}' |
+	# convert back to YAML
+	ruby -ryaml -rjson -e 'puts JSON.load(ARGF).to_yaml' |
+	# escape the double quotes in preparation for insertion back into the configmap
+	sed 's/"/\\"/g'
+)
+# replace the existing configmap with the new one containing the secrets binding
+oc -n openshift-automation-service-broker get cm broker-config -o json --export | jq -r ".data.\"broker-config\" = \"$updatedBrokerConfig\"" | oc -n openshift-automation-service-broker replace -f -
+# rollout the service with the new configmap
+oc -n openshift-automation-service-broker rollout latest dc/openshift-automation-service-broker
+# wait on the rollout
+oc -n openshift-automation-service-broker rollout status dc/openshift-automation-service-broker
+
+mariadb_root_password=$(oc -n mariadb-cluster get secret dbcluster-mariadb -o json | jq -r '.data."mariadb-root-password"' | base64 -d)
+
+# insert the required secrets into the right place
+oc -n openshift-automation-service-broker apply -f - <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dbaas-db-credentials
+type: Opaque
+stringData:
+  production_mariadb_hostname: dbcluster-mariadb.mariadb-cluster.svc.cluster.local
+  production_mariadb_readreplica_hostname: dbcluster-mariadb.mariadb-cluster.svc.cluster.local
+  production_mariadb_password: $mariadb_root_password
+  production_mariadb_port: '3306'
+  production_mariadb_user: root
+  development_mariadb_hostname: dbcluster-mariadb.mariadb-cluster.svc.cluster.local
+  development_mariadb_readreplica_hostname: dbcluster-mariadb.mariadb-cluster.svc.cluster.local
+  development_mariadb_password: $mariadb_root_password
+  development_mariadb_port: '3306'
+  development_mariadb_user: root
+EOF
+
+# switch back to myproject
+oc project myproject

--- a/minishift-test.sh
+++ b/minishift-test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+provision() {
+	run svcat provision test-dbaas \
+		--class localregistry-dbaas-mariadb-apb \
+		--plan $1 \
+		--wait
+	echo "$output"
+	[[ $status -eq 0 ]]
+}
+
+bind() {
+	run svcat bind test-dbaas \
+		--name test-dbaas-binding \
+		--secret-name test-dbaas-secret \
+		--wait
+	echo "$output"
+	[[ $status -eq 0 ]]
+}
+
+check_secret() {
+	run bash -c '
+			set -euo pipefail
+			data=$(oc get secret test-dbaas-secret -o json --export | jq -e ".data")
+			echo Secret data:
+			echo "$data"
+			echo "$data" | jq -e "select(
+				.DB_HOST? and
+				.DB_READREPLICA_HOST? and
+				.DB_NAME? and
+				.DB_PASSWORD? and
+				.DB_PORT? and
+				.DB_TYPE? and
+				.DB_USER?
+				)"
+		'
+	echo "$output"
+	[[ $status -eq 0 ]]
+}
+
+unbind() {
+	run svcat unbind test-dbaas \
+		--wait
+	echo "$output"
+	[[ $status -eq 0 ]]
+}
+
+deprovision() {
+	run svcat deprovision test-dbaas \
+		--wait
+	echo "$output"
+	[[ $status -eq 0 ]]
+}
+
+@test "provision a service (development)" {
+	provision development
+}
+
+@test "bind the secret (development)" {
+	bind
+}
+
+@test "check the contents of the secret (development)" {
+	check_secret
+}
+
+@test "unbind the secret (development)" {
+	unbind
+}
+
+@test "deprovision the service (development)" {
+	deprovision
+}
+
+@test "provision a service (production)" {
+	provision production
+}
+
+@test "bind the secret (production)" {
+	bind
+}
+
+@test "check the contents of the secret (production)" {
+	check_secret
+}
+
+@test "unbind the secret (production)" {
+	unbind
+}
+
+@test "deprovision the service (production)" {
+	deprovision
+}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: read DB credentials
   set_fact:
     mariadb_hostname: "{{ lookup('file', secret ~ 'mariadb_hostname') }}"
-    mariadb_reader_hostname: "{{ lookup('file', secret ~ 'mariadb_reader_hostname') }}"
+    mariadb_readreplica_hostname: "{{ lookup('file', secret ~ 'mariadb_readreplica_hostname') }}"
     mariadb_port: "{{ lookup('file', secret ~ 'mariadb_port') }}"
     mariadb_user: "{{ lookup('file', secret ~ 'mariadb_user') }}"
     mariadb_password: "{{ lookup('file', secret ~ 'mariadb_password') }}"
@@ -31,7 +31,7 @@
           DB_TYPE: "{{ 'mariadb' }}"
           DB_NAME: "{{ create_db_name }}"
           DB_HOST: "{{ app_name }}"
-          DB_READER_HOST: "{{ app_reader_name }}"
+          DB_READREPLICA_HOST: "{{ app_readreplica_name }}"
           DB_PORT: "{{ mariadb_port }}"
           DB_USER: "{{ create_db_user }}"
           DB_PASSWORD: "{{ create_db_password }}"
@@ -82,13 +82,13 @@
     type: ExternalName
     external_name: "{{ mariadb_hostname }}"
 
-- name: "{{ apb_action }} OpenShift service"
+- name: "{{ apb_action }} OpenShift readreplica service"
   k8s_v1_service:
     state: "{{ ensure_state }}"
-    name: "{{ app_reader_name }}"
+    name: "{{ app_readreplica_name }}"
     namespace: "{{ namespace }}"
     type: ExternalName
-    external_name: "{{ mariadb_reader_hostname }}"
+    external_name: "{{ mariadb_readreplica_hostname }}"
 
 - name: "{{ apb_action }} secret with DB credentials"
   k8s:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,15 +8,15 @@
 
 - set_fact:
     ensure_state: "{{ (apb_action == 'provision') | ternary('present', 'absent') }}"
-    secret: "/etc/apb-secrets/apb-lagoon-dbaas-db-credentials/{% if _apb_plan_id == 'default'%}production{% else %}{{ _apb_plan_id }}{% endif %}"
+    secret: "/etc/apb-secrets/apb-dbaas-db-credentials/{% if _apb_plan_id == 'default'%}production{% else %}{{ _apb_plan_id }}{% endif %}_"
 
 - name: read DB credentials
   set_fact:
-    mariadb_hostname: "{{ lookup('file', secret ~ '_mariadb_hostname') }}"
-    mariadb_reader_hostname: "{{ lookup('file', secret ~ '_mariadb_reader_hostname') }}"
-    mariadb_port: "{{ lookup('file', secret ~ '_mariadb_port') }}"
-    mariadb_user: "{{ lookup('file', secret ~ '_mariadb_user') }}"
-    mariadb_password: "{{ lookup('file', secret ~ '_mariadb_password') }}"
+    mariadb_hostname: "{{ lookup('file', secret ~ 'mariadb_hostname') }}"
+    mariadb_reader_hostname: "{{ lookup('file', secret ~ 'mariadb_reader_hostname') }}"
+    mariadb_port: "{{ lookup('file', secret ~ 'mariadb_port') }}"
+    mariadb_user: "{{ lookup('file', secret ~ 'mariadb_user') }}"
+    mariadb_password: "{{ lookup('file', secret ~ 'mariadb_password') }}"
 
 - name: generate DB credentials
   when: apb_action == 'provision'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: read DB credentials
   set_fact:
     mariadb_hostname: "{{ lookup('file', secret ~ '_mariadb_hostname') }}"
+    mariadb_reader_hostname: "{{ lookup('file', secret ~ '_mariadb_reader_hostname') }}"
     mariadb_port: "{{ lookup('file', secret ~ '_mariadb_port') }}"
     mariadb_user: "{{ lookup('file', secret ~ '_mariadb_user') }}"
     mariadb_password: "{{ lookup('file', secret ~ '_mariadb_password') }}"
@@ -30,6 +31,7 @@
           DB_TYPE: "{{ 'mariadb' }}"
           DB_NAME: "{{ create_db_name }}"
           DB_HOST: "{{ app_name }}"
+          DB_READER_HOST: "{{ app_reader_name }}"
           DB_PORT: "{{ mariadb_port }}"
           DB_USER: "{{ create_db_user }}"
           DB_PASSWORD: "{{ create_db_password }}"
@@ -79,6 +81,14 @@
     namespace: "{{ namespace }}"
     type: ExternalName
     external_name: "{{ mariadb_hostname }}"
+
+- name: "{{ apb_action }} OpenShift service"
+  k8s_v1_service:
+    state: "{{ ensure_state }}"
+    name: "{{ app_reader_name }}"
+    namespace: "{{ namespace }}"
+    type: ExternalName
+    external_name: "{{ mariadb_reader_hostname }}"
 
 - name: "{{ apb_action }} secret with DB credentials"
   k8s:


### PR DESCRIPTION
Adds support for a read-replica to be defined in service bindings.

Also adds development documentation, development scripts, and a very basic test suite.
